### PR TITLE
Adds support for package v2 and unit test for decoding

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
   name: "GithubStats",
   platforms: [
-    .macOS(.v12)
+    .macOS(.v12),
   ],
   products: [
     .executable(
@@ -14,25 +14,25 @@ let package = Package(
       targets: ["GithubStats"]),
     .library(
       name: "GithubStatsCore",
-      targets: ["GithubStatsCore"])
+      targets: ["GithubStatsCore"]),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.4"),
-    .package(url: "https://github.com/onevcat/Rainbow", from: "4.0.1")
+    .package(url: "https://github.com/onevcat/Rainbow", from: "4.0.1"),
   ],
   targets: [
     .executableTarget(
       name: "GithubStats",
       dependencies: [
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        "GithubStatsCore"
+        "GithubStatsCore",
       ]),
     .target(
       name: "GithubStatsCore",
       dependencies: [
-        .product(name: "Rainbow", package: "Rainbow")
+        .product(name: "Rainbow", package: "Rainbow"),
       ]),
     .testTarget(
       name: "GithubStatsTests",
-      dependencies: ["GithubStatsCore"])
+      dependencies: ["GithubStatsCore"]),
   ])

--- a/Sources/GithubStats/Commands/LatestReleasesCommand.swift
+++ b/Sources/GithubStats/Commands/LatestReleasesCommand.swift
@@ -21,7 +21,7 @@ struct LatestReleasesCommand: ParsableCommand, AsyncParsableCommand {
     let latestRelease = LatestReleases(
       token: token,
       resolvedPackagePath: resolvedPackage,
-      version: version ?? .v1)
+      version: version ?? .v2)
     let data = try await latestRelease.run()
     let printer = ColorfulPrinter()
     printer.printSummary(for: data)

--- a/Sources/GithubStats/Commands/LatestReleasesCommand.swift
+++ b/Sources/GithubStats/Commands/LatestReleasesCommand.swift
@@ -3,7 +3,6 @@ import Foundation
 import GithubStatsCore
 
 struct LatestReleasesCommand: ParsableCommand, AsyncParsableCommand {
-
   static var configuration: CommandConfiguration {
     CommandConfiguration(commandName: "latest-release")
   }
@@ -26,13 +25,10 @@ struct LatestReleasesCommand: ParsableCommand, AsyncParsableCommand {
     let printer = ColorfulPrinter()
     printer.printSummary(for: data)
   }
-
 }
 
 extension PackageVersion: ExpressibleByArgument {
-
   public init?(argument: String) {
     self.init(rawValue: argument)
   }
-
 }

--- a/Sources/GithubStats/Commands/WorkflowsCommand.swift
+++ b/Sources/GithubStats/Commands/WorkflowsCommand.swift
@@ -3,7 +3,6 @@ import Foundation
 import GithubStatsCore
 
 struct WorkflowsCommand: ParsableCommand, AsyncParsableCommand {
-
   static var configuration: CommandConfiguration {
     CommandConfiguration(commandName: "workflow")
   }
@@ -57,5 +56,4 @@ struct WorkflowsCommand: ParsableCommand, AsyncParsableCommand {
       parameters: parameters)
     try await githubActionCore.run()
   }
-
 }

--- a/Sources/GithubStats/GithubStats.swift
+++ b/Sources/GithubStats/GithubStats.swift
@@ -4,14 +4,12 @@ import GithubStatsCore
 
 @main
 struct GithubStats: ParsableCommand, AsyncParsableCommand {
-
   static var configuration: CommandConfiguration {
     CommandConfiguration(
       commandName: "github-actions-stats",
       subcommands: [
         WorkflowsCommand.self,
-        LatestReleasesCommand.self
+        LatestReleasesCommand.self,
       ])
   }
-
 }

--- a/Sources/GithubStatsCore/LatestReleases.swift
+++ b/Sources/GithubStatsCore/LatestReleases.swift
@@ -5,7 +5,6 @@ public enum PackageVersion: String {
 }
 
 public struct LatestReleases {
-
   // MARK: Lifecycle
 
   public init(

--- a/Sources/GithubStatsCore/Models/CombinedResponse.swift
+++ b/Sources/GithubStatsCore/Models/CombinedResponse.swift
@@ -25,7 +25,7 @@ public struct CombinedResponse: PrintableData {
 
   // MARK: Lifecycle
 
-  internal init(data: GithubRepositoryResponseProtocol, package: Pin) {
+  init(data: GithubRepositoryResponseProtocol, package: Pin) {
     self.data = data
     self.package = package
     diff = data.validate(currentTag: package.tag)
@@ -37,11 +37,11 @@ public struct CombinedResponse: PrintableData {
   public let data: GithubRepositoryResponseProtocol
   public let package: Pin
 
-  public func printingData(using: DateFormatter) {
+  public func printingData(using _: DateFormatter) {
     assertionFailure("Not implemented")
   }
 
-  public func printingColorfulData(using: DateFormatter) {
+  public func printingColorfulData(using _: DateFormatter) {
     print(getColorfulData())
   }
 

--- a/Sources/GithubStatsCore/Models/DecodablePin.swift
+++ b/Sources/GithubStatsCore/Models/DecodablePin.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+protocol DecodablePin: Decodable, Pin {
+    var repositoryURL: URL { get }
+    var state: State { get }
+}
+extension DecodablePin {
+    
+    var tag: String? {
+        state.version
+    }
+    
+    var name: String {
+        repositoryURL.repository
+    }
+    
+    var owner: String {
+        repositoryURL.owner
+    }
+    
+    var sha: String? {
+        state.revision
+    }
+    
+    var hasVersion: Bool {
+        state.hasVersion
+    }
+    
+    func fetch(
+        token: String,
+        using networking: Networking,
+        decoder: JSONDecoder)
+    async throws -> GithubRepositoryResponseProtocol
+    {
+        if state.hasVersion {
+            let request = try state.generateURL(token: token, url: repositoryURL)
+            let data = try await networking.fetch(urlRequest: request)
+            let values = try decoder
+                .decode([FailableDecodable<GithubReleaseResponse>].self, from: data)
+                .compactMap { $0.value }
+                .filter { $0.tag != nil }
+                .sorted(by: { r1, r2 in
+                    r1.tag?.compare(r2.tag ?? "", options: .numeric) == .orderedAscending
+                })
+            return values.last!
+        } else {
+            let request = try state.generateURL(token: token, url: repositoryURL)
+            let data = try await networking.fetch(urlRequest: request)
+            return try decoder.decode([GithubCommitResponse].self, from: data).first!
+        }
+    }
+}

--- a/Sources/GithubStatsCore/Models/DecodablePin.swift
+++ b/Sources/GithubStatsCore/Models/DecodablePin.swift
@@ -1,52 +1,52 @@
 import Foundation
 
 protocol DecodablePin: Decodable, Pin {
-    var repositoryURL: URL { get }
-    var state: State { get }
+  var repositoryURL: URL { get }
+  var state: State { get }
 }
+
 extension DecodablePin {
-    
-    var tag: String? {
-        state.version
-    }
-    
-    var name: String {
-        repositoryURL.repository
-    }
-    
-    var owner: String {
-        repositoryURL.owner
-    }
-    
-    var sha: String? {
-        state.revision
-    }
-    
-    var hasVersion: Bool {
-        state.hasVersion
-    }
-    
-    func fetch(
-        token: String,
-        using networking: Networking,
-        decoder: JSONDecoder)
+  var tag: String? {
+    state.version
+  }
+
+  var name: String {
+    repositoryURL.repository
+  }
+
+  var owner: String {
+    repositoryURL.owner
+  }
+
+  var sha: String? {
+    state.revision
+  }
+
+  var hasVersion: Bool {
+    state.hasVersion
+  }
+
+  func fetch(
+    token: String,
+    using networking: Networking,
+    decoder: JSONDecoder)
     async throws -> GithubRepositoryResponseProtocol
-    {
-        if state.hasVersion {
-            let request = try state.generateURL(token: token, url: repositoryURL)
-            let data = try await networking.fetch(urlRequest: request)
-            let values = try decoder
-                .decode([FailableDecodable<GithubReleaseResponse>].self, from: data)
-                .compactMap { $0.value }
-                .filter { $0.tag != nil }
-                .sorted(by: { r1, r2 in
-                    r1.tag?.compare(r2.tag ?? "", options: .numeric) == .orderedAscending
-                })
-            return values.last!
-        } else {
-            let request = try state.generateURL(token: token, url: repositoryURL)
-            let data = try await networking.fetch(urlRequest: request)
-            return try decoder.decode([GithubCommitResponse].self, from: data).first!
-        }
+  {
+    if state.hasVersion {
+      let request = try state.generateURL(token: token, url: repositoryURL)
+      let data = try await networking.fetch(urlRequest: request)
+      let values = try decoder
+        .decode([FailableDecodable<GithubReleaseResponse>].self, from: data)
+        .compactMap { $0.value }
+        .filter { $0.tag != nil }
+        .sorted(by: { r1, r2 in
+          r1.tag?.compare(r2.tag ?? "", options: .numeric) == .orderedAscending
+        })
+      return values.last!
+    } else {
+      let request = try state.generateURL(token: token, url: repositoryURL)
+      let data = try await networking.fetch(urlRequest: request)
+      return try decoder.decode([GithubCommitResponse].self, from: data).first!
     }
+  }
 }

--- a/Sources/GithubStatsCore/Models/GithubRepositoryResponseProtocol.swift
+++ b/Sources/GithubStatsCore/Models/GithubRepositoryResponseProtocol.swift
@@ -85,7 +85,6 @@ extension String {
 }
 
 extension String {
-
   var version: String? {
     let str = split(separator: "/")
       .last?

--- a/Sources/GithubStatsCore/Models/Parameters.swift
+++ b/Sources/GithubStatsCore/Models/Parameters.swift
@@ -8,7 +8,7 @@ public enum Request: Equatable {
   var url: String {
     let url = Request.base
     switch self {
-    case .workflowRun(let id):
+    case let .workflowRun(id):
       return url + "%@/%@/actions/workflows/\(id)/runs"
     case .latestRelease:
       return url + "%@/%@/git/refs/tags"
@@ -18,7 +18,6 @@ public enum Request: Equatable {
   }
 
   private static let base = "https://api.github.com/repos/"
-
 }
 
 public struct Parameters {
@@ -79,8 +78,7 @@ public struct Parameters {
   let branch: String?
   let skipPrintingStats: Bool
 
-  func generateURLRequest(withPage page: Int) throws -> URLRequest
-  {
+  func generateURLRequest(withPage page: Int) throws -> URLRequest {
     let str = String(format: request.url, owner, repository)
     guard let url = URL(string: str) else {
       throw Errors.invalidURL(str: str)
@@ -122,7 +120,7 @@ public struct Parameters {
     var request = URLRequest(url: url)
     request.allHTTPHeaderFields = [
       "Authorization": "Bearer \(token)",
-      "Accept": "application/vnd.github+json"
+      "Accept": "application/vnd.github+json",
     ]
     return request
   }

--- a/Sources/GithubStatsCore/Models/State.swift
+++ b/Sources/GithubStatsCore/Models/State.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct State: Decodable {
+  let branch: String?
+  let revision: String?
+  let version: String?
+
+  var hasVersion: Bool {
+    version != nil
+  }
+
+  func generateURL(token: String, url: URL) throws -> URLRequest {
+    let params = Parameters(
+      token: token,
+      url: url,
+      request: hasVersion ? .latestRelease : .latestCommit,
+      branch: branch)
+    return try params.generateURLRequest(withPage: 1)
+  }
+}

--- a/Sources/GithubStatsCore/Models/V1SwiftResolvedPackage.swift
+++ b/Sources/GithubStatsCore/Models/V1SwiftResolvedPackage.swift
@@ -16,9 +16,9 @@ struct V1SwiftResolvedPackage: Decodable {
     self.pins = try pins.decode([V1Package].self, forKey: .pins)
     version = try container.decode(Int.self, forKey: .version)
   }
+
   let pins: [V1Package]
   let version: Int
-
 }
 
 struct V1Package: DecodablePin {

--- a/Sources/GithubStatsCore/Models/V1SwiftResolvedPackage.swift
+++ b/Sources/GithubStatsCore/Models/V1SwiftResolvedPackage.swift
@@ -13,82 +13,16 @@ struct V1SwiftResolvedPackage: Decodable {
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let pins = try container.nestedContainer(keyedBy: NestedCodingKeys.self, forKey: .object)
-    self.pins = try pins.decode([V1Packages].self, forKey: .pins)
+    self.pins = try pins.decode([V1Package].self, forKey: .pins)
     version = try container.decode(Int.self, forKey: .version)
   }
-  let pins: [V1Packages]
+  let pins: [V1Package]
   let version: Int
 
 }
 
-struct V1Packages: Decodable {
+struct V1Package: DecodablePin {
   let package: String
   let repositoryURL: URL
-  let state: V1State
-}
-
-extension V1Packages: Pin {
-
-  var tag: String? {
-    state.version
-  }
-
-  var name: String {
-    repositoryURL.repository
-  }
-
-  var owner: String {
-    repositoryURL.owner
-  }
-
-  var sha: String? {
-    state.revision
-  }
-
-  var hasVersion: Bool {
-    state.hasVersion
-  }
-
-  func fetch(
-    token: String,
-    using networking: Networking,
-    decoder: JSONDecoder)
-    async throws -> GithubRepositoryResponseProtocol
-  {
-    if state.hasVersion {
-      let request = try state.generateURL(token: token, url: repositoryURL)
-      let data = try await networking.fetch(urlRequest: request)
-      let values = try decoder
-        .decode([FailableDecodable<GithubReleaseResponse>].self, from: data)
-        .compactMap { $0.value }
-        .filter { $0.tag != nil }
-        .sorted(by: { r1, r2 in
-          r1.tag?.compare(r2.tag ?? "", options: .numeric) == .orderedAscending
-        })
-      return values.last!
-    } else {
-      let request = try state.generateURL(token: token, url: repositoryURL)
-      let data = try await networking.fetch(urlRequest: request)
-      return try decoder.decode([GithubCommitResponse].self, from: data).first!
-    }
-  }
-}
-
-struct V1State: Decodable {
-  let branch: String?
-  let revision: String?
-  let version: String?
-
-  var hasVersion: Bool {
-    version != nil
-  }
-
-  func generateURL(token: String, url: URL) throws -> URLRequest {
-    let params = Parameters(
-      token: token,
-      url: url,
-      request: hasVersion ? .latestRelease : .latestCommit,
-      branch: branch)
-    return try params.generateURLRequest(withPage: 1)
-  }
+  let state: State
 }

--- a/Sources/GithubStatsCore/Models/V2SwiftResolvedPackage.swift
+++ b/Sources/GithubStatsCore/Models/V2SwiftResolvedPackage.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct V2SwiftResolvedPackage: Decodable {
+  let pins: [V2Package]
+  let version: Int
+}
+
+struct V2Package: DecodablePin {
+  let identity: String
+  let repositoryURL: URL
+  let state: State
+
+  enum CodingKeys: String, CodingKey {
+    case identity
+    case repositoryURL = "location"
+    case state
+  }
+}

--- a/Sources/GithubStatsCore/Services/GithubStatistics.swift
+++ b/Sources/GithubStatsCore/Services/GithubStatistics.swift
@@ -47,5 +47,4 @@ struct GithubStatistics {
   // MARK: Private
 
   private let response: GithubActionResponses
-
 }

--- a/Sources/GithubStatsCore/Services/LatestReleasesWorker.swift
+++ b/Sources/GithubStatsCore/Services/LatestReleasesWorker.swift
@@ -30,8 +30,8 @@ final class LatestReleasesWorker {
       let decodedData = try decoder.decode(V1SwiftResolvedPackage.self, from: data)
       return try await fetchPackagesFrom(pins: decodedData.pins)
     case .v2:
-        let decodedData = try decoder.decode(V2SwiftResolvedPackage.self, from: data)
-        return try await fetchPackagesFrom(pins: decodedData.pins)
+      let decodedData = try decoder.decode(V2SwiftResolvedPackage.self, from: data)
+      return try await fetchPackagesFrom(pins: decodedData.pins)
     }
   }
 

--- a/Sources/GithubStatsCore/Services/LatestReleasesWorker.swift
+++ b/Sources/GithubStatsCore/Services/LatestReleasesWorker.swift
@@ -30,7 +30,8 @@ final class LatestReleasesWorker {
       let decodedData = try decoder.decode(V1SwiftResolvedPackage.self, from: data)
       return try await fetchPackagesFrom(pins: decodedData.pins)
     case .v2:
-      return []
+        let decodedData = try decoder.decode(V2SwiftResolvedPackage.self, from: data)
+        return try await fetchPackagesFrom(pins: decodedData.pins)
     }
   }
 

--- a/Sources/GithubStatsCore/Services/Networking.swift
+++ b/Sources/GithubStatsCore/Services/Networking.swift
@@ -5,7 +5,6 @@ public protocol URLSessionProtocol {
 }
 
 extension URLSession: URLSessionProtocol {
-
   public func dataAndStatusCode(for urlRequest: URLRequest) async throws -> (Data, Int) {
     let (data, response) = try await data(for: urlRequest)
     let httpResponse = response as? HTTPURLResponse
@@ -14,7 +13,6 @@ extension URLSession: URLSessionProtocol {
 }
 
 public struct Networking {
-
   init(session: URLSessionProtocol) {
     self.session = session
   }

--- a/Sources/GithubStatsCore/Services/Printer.swift
+++ b/Sources/GithubStatsCore/Services/Printer.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 public struct ColorfulPrinter {
-
   public init() {}
 
   // MARK: Internal
@@ -17,11 +16,9 @@ public struct ColorfulPrinter {
     dateFormatter.dateFormat = "MMM d, yyyy"
     return dateFormatter
   }()
-
 }
 
 struct Printer {
-
   // MARK: Internal
 
   func printSummary<T: PrintableData>(for item: T) {
@@ -54,8 +51,7 @@ public protocol PrintableData {
 }
 
 extension Statistics: PrintableData {
-
-  public func printingColorfulData(using: DateFormatter) {
+  public func printingColorfulData(using _: DateFormatter) {
     assertionFailure("Not implemented")
   }
 
@@ -65,7 +61,7 @@ extension Statistics: PrintableData {
     let startDate = dateFormatter.string(from: startDate)
     let endDate = dateFormatter.string(from: endDate)
     print("range: \(startDate) - \(endDate)")
-    statuses.forEach { k, v in
+    for (k, v) in statuses {
       let percentage = Double(v.count) / totalRuns
       print("status: \(k) ---")
       print("percentage: \(Int(percentage * 100))")
@@ -91,5 +87,4 @@ extension Array: PrintableData where Element: PrintableData {
       item.printingData(using: dateformatter)
     }
   }
-
 }

--- a/Sources/GithubStatsCore/Workflows.swift
+++ b/Sources/GithubStatsCore/Workflows.swift
@@ -58,5 +58,4 @@ public struct Workflows {
     return GithubActionResponses(
       responses: githubResponses)
   }
-
 }

--- a/Tests/GithubStatsTests/DecodableTests.swift
+++ b/Tests/GithubStatsTests/DecodableTests.swift
@@ -5,57 +5,59 @@ import XCTest
 
 final class DecodableTests: XCTestCase {
 
+  // MARK: Internal
+
   func testDecodeV1() {
-      let string = """
-      {
-        "object": {
-          "pins": [
-            {
-              "package": "swift-nio",
-              "repositoryURL": "https://github.com/apple/swift-nio.git",
-              "state": {
-                "branch": null,
-                "revision": "ad3c2f1b726549f5d2cd73350d96c3cfc4123075",
-                "version": "2.32.0"
-              }
-            },
-            {
-              "package": "swift-algorithms",
-              "repositoryURL": "https://github.com/apple/swift-algorithms.git",
-              "state": {
-                "branch": "main",
-                "revision": "64ad02f8f5a9c2bd98f2ad6c389e6e86bc2d5b47",
-                "version": null
-              }
-            },
-            {
-              "package": "swift-collections",
-              "repositoryURL": "https://github.com/apple/swift-collections.git",
-              "state": {
-                "branch": null,
-                "revision": "81d1e46256483b2f23b61eb1a588ff5c8d37e9b9",
-                "version": null
-              }
+    let string = """
+    {
+      "object": {
+        "pins": [
+          {
+            "package": "swift-nio",
+            "repositoryURL": "https://github.com/apple/swift-nio.git",
+            "state": {
+              "branch": null,
+              "revision": "ad3c2f1b726549f5d2cd73350d96c3cfc4123075",
+              "version": "2.32.0"
             }
-          ]
-        },
-        "version": 1
-      }
-      """
-      
-      let data = string.data(using: .utf8)!
-      let package = try! decoder.decode(V1SwiftResolvedPackage.self, from: data)
-      
-      XCTAssertEqual(package.version, 1)
-      XCTAssertEqual(package.pins[0].tag, "2.32.0")
-      XCTAssertEqual(package.pins[0].sha, "ad3c2f1b726549f5d2cd73350d96c3cfc4123075")
-      XCTAssertEqual(package.pins[0].hasVersion, true)
-      XCTAssertEqual(package.pins[0].name, "swift-nio")
-      XCTAssertEqual(package.pins[0].owner, "apple")
-      
-      XCTAssertEqual(package.pins[1].tag, nil)
-      XCTAssertEqual(package.pins[1].sha, "64ad02f8f5a9c2bd98f2ad6c389e6e86bc2d5b47")
-      XCTAssertEqual(package.pins[1].hasVersion, false)
+          },
+          {
+            "package": "swift-algorithms",
+            "repositoryURL": "https://github.com/apple/swift-algorithms.git",
+            "state": {
+              "branch": "main",
+              "revision": "64ad02f8f5a9c2bd98f2ad6c389e6e86bc2d5b47",
+              "version": null
+            }
+          },
+          {
+            "package": "swift-collections",
+            "repositoryURL": "https://github.com/apple/swift-collections.git",
+            "state": {
+              "branch": null,
+              "revision": "81d1e46256483b2f23b61eb1a588ff5c8d37e9b9",
+              "version": null
+            }
+          }
+        ]
+      },
+      "version": 1
+    }
+    """
+
+    let data = string.data(using: .utf8)!
+    let package = try! decoder.decode(V1SwiftResolvedPackage.self, from: data)
+
+    XCTAssertEqual(package.version, 1)
+    XCTAssertEqual(package.pins[0].tag, "2.32.0")
+    XCTAssertEqual(package.pins[0].sha, "ad3c2f1b726549f5d2cd73350d96c3cfc4123075")
+    XCTAssertEqual(package.pins[0].hasVersion, true)
+    XCTAssertEqual(package.pins[0].name, "swift-nio")
+    XCTAssertEqual(package.pins[0].owner, "apple")
+
+    XCTAssertEqual(package.pins[1].tag, nil)
+    XCTAssertEqual(package.pins[1].sha, "64ad02f8f5a9c2bd98f2ad6c389e6e86bc2d5b47")
+    XCTAssertEqual(package.pins[1].hasVersion, false)
   }
 
   func testDecodeV2() {
@@ -93,22 +95,24 @@ final class DecodableTests: XCTestCase {
       "version": 2
     }
     """
-      
-      let data = string.data(using: .utf8)!
-      let package = try! decoder.decode(V2SwiftResolvedPackage.self, from: data)
 
-      XCTAssertEqual(package.version, 2)
-      XCTAssertEqual(package.pins[0].tag, "2.32.0")
-      XCTAssertEqual(package.pins[0].sha, "ad3c2f1b726549f5d2cd73350d96c3cfc4123075")
-      XCTAssertEqual(package.pins[0].hasVersion, true)
-      XCTAssertEqual(package.pins[0].name, "swift-nio")
-      XCTAssertEqual(package.pins[0].owner, "apple")
-      
-      XCTAssertEqual(package.pins[1].tag, nil)
-      XCTAssertEqual(package.pins[1].sha, "64ad02f8f5a9c2bd98f2ad6c389e6e86bc2d5b47")
-      XCTAssertEqual(package.pins[1].hasVersion, false)
+    let data = string.data(using: .utf8)!
+    let package = try! decoder.decode(V2SwiftResolvedPackage.self, from: data)
+
+    XCTAssertEqual(package.version, 2)
+    XCTAssertEqual(package.pins[0].tag, "2.32.0")
+    XCTAssertEqual(package.pins[0].sha, "ad3c2f1b726549f5d2cd73350d96c3cfc4123075")
+    XCTAssertEqual(package.pins[0].hasVersion, true)
+    XCTAssertEqual(package.pins[0].name, "swift-nio")
+    XCTAssertEqual(package.pins[0].owner, "apple")
+
+    XCTAssertEqual(package.pins[1].tag, nil)
+    XCTAssertEqual(package.pins[1].sha, "64ad02f8f5a9c2bd98f2ad6c389e6e86bc2d5b47")
+    XCTAssertEqual(package.pins[1].hasVersion, false)
   }
-    
+
+  // MARK: Private
+
   private lazy var decoder: JSONDecoder = {
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .iso8601

--- a/Tests/GithubStatsTests/DecodableTests.swift
+++ b/Tests/GithubStatsTests/DecodableTests.swift
@@ -1,0 +1,118 @@
+
+import XCTest
+
+@testable import GithubStatsCore
+
+final class DecodableTests: XCTestCase {
+
+  func testDecodeV1() {
+      let string = """
+      {
+        "object": {
+          "pins": [
+            {
+              "package": "swift-nio",
+              "repositoryURL": "https://github.com/apple/swift-nio.git",
+              "state": {
+                "branch": null,
+                "revision": "ad3c2f1b726549f5d2cd73350d96c3cfc4123075",
+                "version": "2.32.0"
+              }
+            },
+            {
+              "package": "swift-algorithms",
+              "repositoryURL": "https://github.com/apple/swift-algorithms.git",
+              "state": {
+                "branch": "main",
+                "revision": "64ad02f8f5a9c2bd98f2ad6c389e6e86bc2d5b47",
+                "version": null
+              }
+            },
+            {
+              "package": "swift-collections",
+              "repositoryURL": "https://github.com/apple/swift-collections.git",
+              "state": {
+                "branch": null,
+                "revision": "81d1e46256483b2f23b61eb1a588ff5c8d37e9b9",
+                "version": null
+              }
+            }
+          ]
+        },
+        "version": 1
+      }
+      """
+      
+      let data = string.data(using: .utf8)!
+      let package = try! decoder.decode(V1SwiftResolvedPackage.self, from: data)
+      
+      XCTAssertEqual(package.version, 1)
+      XCTAssertEqual(package.pins[0].tag, "2.32.0")
+      XCTAssertEqual(package.pins[0].sha, "ad3c2f1b726549f5d2cd73350d96c3cfc4123075")
+      XCTAssertEqual(package.pins[0].hasVersion, true)
+      XCTAssertEqual(package.pins[0].name, "swift-nio")
+      XCTAssertEqual(package.pins[0].owner, "apple")
+      
+      XCTAssertEqual(package.pins[1].tag, nil)
+      XCTAssertEqual(package.pins[1].sha, "64ad02f8f5a9c2bd98f2ad6c389e6e86bc2d5b47")
+      XCTAssertEqual(package.pins[1].hasVersion, false)
+  }
+
+  func testDecodeV2() {
+    let string = """
+    {
+      "pins": [
+        {
+          "identity": "swift-nio",
+          "location": "https://github.com/apple/swift-nio.git",
+          "state": {
+            "branch": null,
+            "revision": "ad3c2f1b726549f5d2cd73350d96c3cfc4123075",
+            "version": "2.32.0"
+          }
+        },
+        {
+          "identity": "swift-algorithms",
+          "location": "https://github.com/apple/swift-algorithms.git",
+          "state": {
+            "branch": "main",
+            "revision": "64ad02f8f5a9c2bd98f2ad6c389e6e86bc2d5b47",
+            "version": null
+          }
+        },
+        {
+          "identity": "swift-collections",
+          "location": "https://github.com/apple/swift-collections.git",
+          "state": {
+            "branch": null,
+            "revision": "81d1e46256483b2f23b61eb1a588ff5c8d37e9b9",
+            "version": null
+          }
+        }
+      ],
+      "version": 2
+    }
+    """
+      
+      let data = string.data(using: .utf8)!
+      let package = try! decoder.decode(V2SwiftResolvedPackage.self, from: data)
+
+      XCTAssertEqual(package.version, 2)
+      XCTAssertEqual(package.pins[0].tag, "2.32.0")
+      XCTAssertEqual(package.pins[0].sha, "ad3c2f1b726549f5d2cd73350d96c3cfc4123075")
+      XCTAssertEqual(package.pins[0].hasVersion, true)
+      XCTAssertEqual(package.pins[0].name, "swift-nio")
+      XCTAssertEqual(package.pins[0].owner, "apple")
+      
+      XCTAssertEqual(package.pins[1].tag, nil)
+      XCTAssertEqual(package.pins[1].sha, "64ad02f8f5a9c2bd98f2ad6c389e6e86bc2d5b47")
+      XCTAssertEqual(package.pins[1].hasVersion, false)
+  }
+    
+  private lazy var decoder: JSONDecoder = {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    return decoder
+  }()
+}

--- a/Tests/GithubStatsTests/GithubStatisticsTests.swift
+++ b/Tests/GithubStatsTests/GithubStatisticsTests.swift
@@ -3,7 +3,6 @@ import XCTest
 @testable import GithubStatsCore
 
 final class GithubStatisticsTests: XCTestCase {
-
   func testStatisticsFailureRun() {
     let responses = GithubActionResponses(responses: [])
     let statistics = GithubStatistics(response: responses)
@@ -25,14 +24,14 @@ final class GithubStatisticsTests: XCTestCase {
               conclusion: .success,
               runStartedAt: oldest,
               createdAt: oldest,
-              updatedAt: oldest.adding(timeInternal: 1000000)),
+              updatedAt: oldest.adding(timeInternal: 1_000_000)),
             WorkFlow(
               name: "CI-job",
               path: "some.yml",
               conclusion: .success,
               runStartedAt: oldest,
               createdAt: oldest,
-              updatedAt: oldest.adding(timeInternal: 1000000)),
+              updatedAt: oldest.adding(timeInternal: 1_000_000)),
             WorkFlow(
               name: "CI-job",
               path: "some.yml",
@@ -64,29 +63,29 @@ final class GithubStatisticsTests: XCTestCase {
               conclusion: .success,
               runStartedAt: oldest,
               createdAt: oldest,
-              updatedAt: oldest.adding(timeInternal: 900000)),
+              updatedAt: oldest.adding(timeInternal: 900_000)),
             WorkFlow(
               name: "CI-job",
               path: "some.yml",
               conclusion: .success,
               runStartedAt: oldest,
               createdAt: oldest,
-              updatedAt: oldest.adding(timeInternal: 900000)),
+              updatedAt: oldest.adding(timeInternal: 900_000)),
             WorkFlow(
               name: "CI-job",
               path: "some.yml",
               conclusion: .success,
               runStartedAt: oldest,
               createdAt: oldest,
-              updatedAt: oldest.adding(timeInternal: 800000)),
+              updatedAt: oldest.adding(timeInternal: 800_000)),
             WorkFlow(
               name: "CI-job",
               path: "some.yml",
               conclusion: .success,
               runStartedAt: newest,
               createdAt: newest,
-              updatedAt: newest.adding(timeInternal: 1000000)),
-          ])
+              updatedAt: newest.adding(timeInternal: 1_000_000)),
+          ]),
       ])
     let statistics = GithubStatistics(response: responses)
     do {
@@ -94,12 +93,12 @@ final class GithubStatisticsTests: XCTestCase {
       XCTAssertEqual(statistics.name, "some.yml")
       XCTAssertEqual(statistics.workflowCount, 9)
       XCTAssertEqual(statistics.totalRuns, 9)
-      XCTAssertEqual(statistics.averageTime, 5612000.0)
+      XCTAssertEqual(statistics.averageTime, 5_612_000.0)
       XCTAssertEqual(statistics.startDate, oldest)
       XCTAssertEqual(statistics.endDate, newest)
       XCTAssertEqual(statistics.statuses[.inProgress]?.totalRunningTime, 10000.0)
       XCTAssertEqual(statistics.statuses[.inProgress]?.count, 1)
-      XCTAssertEqual(statistics.statuses[.success]?.totalRunningTime, 5600000.0)
+      XCTAssertEqual(statistics.statuses[.success]?.totalRunningTime, 5_600_000.0)
       XCTAssertEqual(statistics.statuses[.success]?.count, 6)
       XCTAssertEqual(statistics.statuses[.failure]?.totalRunningTime, 1000.0)
       XCTAssertEqual(statistics.statuses[.failure]?.count, 1)
@@ -109,7 +108,6 @@ final class GithubStatisticsTests: XCTestCase {
       XCTFail(error.localizedDescription)
     }
   }
-
 }
 
 extension Date {

--- a/Tests/GithubStatsTests/GithubStatsTests.swift
+++ b/Tests/GithubStatsTests/GithubStatsTests.swift
@@ -1,8 +1,0 @@
-import XCTest
-@testable import GithubStatsCore
-
-final class GithubStatsTests: XCTestCase {
-  func testExample() throws {
-    print("Welcome")
-  }
-}

--- a/Tests/GithubStatsTests/Mocks/MockSession.swift
+++ b/Tests/GithubStatsTests/Mocks/MockSession.swift
@@ -3,11 +3,10 @@ import XCTest
 @testable import GithubStatsCore
 
 final class MockSession: URLSessionProtocol {
-
   var data: Data!
   var statusCode: Int!
 
-  func dataAndStatusCode(for: URLRequest) async throws -> (Data, Int) {
+  func dataAndStatusCode(for _: URLRequest) async throws -> (Data, Int) {
     (data, statusCode)
   }
 }

--- a/Tests/GithubStatsTests/ParametersTests.swift
+++ b/Tests/GithubStatsTests/ParametersTests.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import GithubStatsCore
 
 final class ParametersTests: XCTestCase {
-
   func testGeneratingURL() {
     let token = "token"
     let params = Parameters(


### PR DESCRIPTION
I've added support for parsing of `Package.resolved` version 2.  I've also refactored a bit to share the code between v1 and 2 where it was the same, and added a unit test for the decoding. 